### PR TITLE
fix(analysis): filter star dream sidekick characters

### DIFF
--- a/src/components/organisms/analysis/StardreamAnalysis.tsx
+++ b/src/components/organisms/analysis/StardreamAnalysis.tsx
@@ -71,7 +71,7 @@ const StardreamAnalysis: React.FC<AnalysisProps> = ({ allCharacters }) => {
     },
     {
       label: "frontend.analyze.havebuddy",
-      value: targetOptions.filter((char) => char.buddy !== null),
+      value: targetOptions.filter((char) => char.buddy),
     },
     {
       label: "frontend.filter.alter",


### PR DESCRIPTION
## Summary

- Fix Star Dream Encounter's sidekick section to include only characters with an actual buddy object.

## Implementation notes

The character API type allows buddy to be omitted or null, so the filter now excludes both missing and null values.

## Evidence

- lint, type check, tests passed.
- Static review found no issues with the one-line filter change.