### PR TITLE
Fix and speed up the analysis image download

### DIFF
--- a/src/components/atoms/Loading.tsx
+++ b/src/components/atoms/Loading.tsx
@@ -1,9 +1,18 @@
 import { Loader2 } from "lucide-react";
 
-function Loading() {
+interface LoadingProps {
+  message?: string;
+}
+
+function Loading({ message }: LoadingProps) {
   return (
-    <div className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 flex items-center justify-center">
+    <div className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 flex flex-col gap-4 items-center justify-center">
       <Loader2 className="h-12 w-12 animate-spin text-primary" />
+      {message && (
+        <p className="text-sm text-muted-foreground text-center px-6 max-w-xs">
+          {message}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/atoms/button/Download.tsx
+++ b/src/components/atoms/button/Download.tsx
@@ -14,171 +14,32 @@ const AnnounceSwal = withReactContent(Swal);
 
 const DESKTOP_CAPTURE_WIDTH = 1200;
 const CAPTURE_SCALE = 1.1;
-const HIGHLIGHTS = [
-  {
-    selector: '[data-capture-highlight="recent"], .glow-recent',
-    width: 2,
-    color: "#56b4e9",
-  },
-  {
-    selector: '[data-capture-highlight="op"], .glow-op',
-    width: 2,
-    color: "rgba(250, 204, 21, 0.8)",
-  },
-  {
-    selector: '[data-capture-highlight="super_op"], .glow-super-op',
-    width: 4,
-    color: "#fde047",
-  },
-];
-const TRANSPARENT_PIXEL =
-  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
-
-interface CaptureImage {
-  bitmap: HTMLCanvasElement;
-  element: HTMLImageElement;
-  layer: number;
-}
 
 /**
- * Captures the element with every image blanked out and paints the pictures the page has
- * already decoded onto the result.
+ * Copies the picture each image already shows into a canvas the capture can draw
+ * without loading anything.
  *
- * html2canvas reloads each image it draws instead of reusing the decoded one, and it
+ * html2canvas reloads every image by address instead of reusing the decoded one, and it
  * tears its clone down while those loads are still running: a capture holding 250 images
  * lost about 150 of them and the matching character cards came out blank, while one
- * holding 32 lost none. Pointing every image at the same blank pixel leaves the capture
- * with a single picture to load, and the real ones are drawn afterwards from the canvas
- * copies taken here. That copying is what the crossOrigin attribute on the images is
- * for: a canvas holding a plain cross-origin picture cannot be read back.
+ * holding 32 lost none. A canvas needs no loading, which is also why the images carry
+ * crossOrigin="anonymous": a canvas holding a plain cross-origin picture taints the
+ * capture and blocks the export.
  */
-const captureWithImages = async (
-  element: HTMLElement,
-  options: Parameters<typeof html2canvas>[1] & { scale: number }
-) => {
-  const undos: Array<() => void> = [];
-  const set = (target: Element, attribute: string, value: string) => {
-    const original = target.getAttribute(attribute);
-    if (original === null || original === value) return;
-    undos.push(() => target.setAttribute(attribute, original));
-    target.setAttribute(attribute, value);
-  };
+const replaceImagesWithCanvas = (source: HTMLElement, clone: HTMLElement) => {
+  const originals = source.querySelectorAll("img");
+  clone.querySelectorAll("img").forEach((image, index) => {
+    const original = originals[index];
+    if (!original?.naturalWidth) return;
 
-  const bitmaps = new Map<string, HTMLCanvasElement>();
-  const drawings: CaptureImage[] = [];
-
-  element.querySelectorAll("img").forEach((image) => {
-    const rect = image.getBoundingClientRect();
-    // A blanked image that draws its own height would collapse and move everything
-    // below it away from the boxes measured here.
-    set(
-      image,
-      "style",
-      `${image.getAttribute("style") ?? ""};width:${rect.width}px;height:${rect.height}px`
-    );
-
-    if (image.naturalWidth) {
-      let bitmap = bitmaps.get(image.src);
-      if (!bitmap) {
-        bitmap = document.createElement("canvas");
-        bitmap.width = image.naturalWidth;
-        bitmap.height = image.naturalHeight;
-        bitmap.getContext("2d")?.drawImage(image, 0, 0);
-        bitmaps.set(image.src, bitmap);
-      }
-
-      const layer = Number(window.getComputedStyle(image).zIndex);
-      drawings.push({ bitmap, element: image, layer: Number.isNaN(layer) ? 0 : layer });
-    }
-
-    // A <source> outranks the img's own src, so the WebP variants go blank as well.
-    // Only the image's own picture may be touched: reaching further up blanked the
-    // character art before its copy was taken, and every card came out empty.
-    image
-      .closest("picture")
-      ?.querySelectorAll(":scope > source")
-      .forEach((variant) => set(variant, "srcset", TRANSPARENT_PIXEL));
-    set(image, "src", TRANSPARENT_PIXEL);
+    const canvas = image.ownerDocument.createElement("canvas");
+    canvas.width = original.naturalWidth;
+    canvas.height = original.naturalHeight;
+    canvas.getContext("2d")?.drawImage(original, 0, 0);
+    canvas.className = image.className;
+    canvas.style.cssText = image.style.cssText;
+    image.replaceWith(canvas);
   });
-
-  let canvas: HTMLCanvasElement;
-  try {
-    canvas = await html2canvas(element, options);
-  } finally {
-    undos.forEach((undo) => undo());
-  }
-
-  const context = canvas.getContext("2d");
-  if (!context) return canvas;
-
-  // The capture leaves its own scale on the context, which multiplied every coordinate
-  // below a second time and pushed the pictures further down the page the lower they sat.
-  context.setTransform(1, 0, 0, 1, 0, 0);
-
-  const bounds = element.getBoundingClientRect();
-  const place = (target: Element) => {
-    const rect = target.getBoundingClientRect();
-    return {
-      x: (rect.left - bounds.left) * options.scale,
-      y: (rect.top - bounds.top) * options.scale,
-      width: rect.width * options.scale,
-      height: rect.height * options.scale,
-    };
-  };
-
-  // The capture holds the name plates and the highlight rings, which belong above the
-  // pictures, so it is kept aside and those parts are put back afterwards.
-  const captured = document.createElement("canvas");
-  captured.width = canvas.width;
-  captured.height = canvas.height;
-  captured.getContext("2d")?.drawImage(canvas, 0, 0);
-
-  const restore = (x: number, y: number, width: number, height: number) => {
-    if (width <= 0 || height <= 0) return;
-    context.drawImage(captured, x, y, width, height, x, y, width, height);
-  };
-
-  drawings
-    .sort((first, second) => first.layer - second.layer)
-    .forEach(({ bitmap, element: image }) => {
-      const box = place(image);
-      const style = window.getComputedStyle(image);
-
-      context.save();
-      context.filter = style.filter;
-      context.globalAlpha = Number(style.opacity);
-      context.beginPath();
-      context.roundRect(
-        box.x,
-        box.y,
-        box.width,
-        box.height,
-        parseFloat(style.borderTopLeftRadius) * options.scale || 0
-      );
-      context.clip();
-      context.drawImage(bitmap, box.x, box.y, box.width, box.height);
-      context.restore();
-    });
-
-  element.querySelectorAll("picture").forEach((picture) => {
-    const plate = picture.nextElementSibling;
-    if (!plate) return;
-    const box = place(plate);
-    restore(box.x, box.y, box.width, box.height);
-  });
-
-  HIGHLIGHTS.forEach(({ selector, width }) => {
-    const ring = width * options.scale;
-    element.querySelectorAll(selector).forEach((highlighted) => {
-      const box = place(highlighted);
-      restore(box.x, box.y, box.width, ring);
-      restore(box.x, box.y + box.height - ring, box.width, ring);
-      restore(box.x, box.y, ring, box.height);
-      restore(box.x + box.width - ring, box.y, ring, box.height);
-    });
-  });
-
-  return canvas;
 };
 
 interface DownloadProps {
@@ -226,19 +87,16 @@ const DownloadButton: React.FC<DownloadProps> = ({ tag }) => {
       const captureWidth = element.scrollWidth;
       const captureHeight = element.scrollHeight;
 
-      const canvas = await captureWithImages(element, {
+      const canvas = await html2canvas(element, {
         scale: CAPTURE_SCALE,
         allowTaint: true,
         useCORS: true,
         width: captureWidth,
         height: captureHeight,
         backgroundColor: isDark ? '#171717' : '#ffffff',
+        ignoreElements: (element) => element.id === "downloader",
         onclone: (_: Document, clonedElement: HTMLElement) => {
-          // The button is hidden rather than dropped from the capture: dropping it took
-          // its height out of the layout, and everything below sat about 30px higher
-          // than the page it was measured from.
-          const downloader = clonedElement.querySelector<HTMLElement>("#downloader");
-          if (downloader) downloader.style.visibility = "hidden";
+          replaceImagesWithCanvas(element, clonedElement);
 
           clonedElement.style.width = `${captureWidth}px`;
           clonedElement.style.height = `${captureHeight}px`;
@@ -247,7 +105,22 @@ const DownloadButton: React.FC<DownloadProps> = ({ tag }) => {
           clonedElement.scrollLeft = 0;
           clonedElement.scrollTop = 0;
 
-          HIGHLIGHTS.forEach(({ selector, width, color }) => {
+          const highlights = [
+            {
+              selector: '[data-capture-highlight="recent"], .glow-recent',
+              border: "2px solid #56b4e9",
+            },
+            {
+              selector: '[data-capture-highlight="op"], .glow-op',
+              border: "2px solid rgba(250, 204, 21, 0.8)",
+            },
+            {
+              selector: '[data-capture-highlight="super_op"], .glow-super-op',
+              border: "4px solid #fde047",
+            },
+          ];
+
+          highlights.forEach(({ selector, border }) => {
             clonedElement.querySelectorAll<HTMLElement>(selector).forEach((highlighted) => {
               highlighted.style.setProperty("box-shadow", "none", "important");
               const position = highlighted.ownerDocument.defaultView
@@ -260,7 +133,7 @@ const DownloadButton: React.FC<DownloadProps> = ({ tag }) => {
               Object.assign(overlay.style, {
                 position: "absolute",
                 inset: "0",
-                border: `${width}px solid ${color}`,
+                border,
                 borderRadius: "inherit",
                 boxSizing: "border-box",
                 pointerEvents: "none",

--- a/src/components/atoms/button/Download.tsx
+++ b/src/components/atoms/button/Download.tsx
@@ -12,6 +12,128 @@ import { isIOS } from "react-device-detect";
 
 const AnnounceSwal = withReactContent(Swal);
 
+const DESKTOP_CAPTURE_WIDTH = 1200;
+const CAPTURE_SCALE = 1.1;
+const CAPTURE_BATCH_SIZE = 100;
+const TRANSPARENT_PIXEL =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+
+/**
+ * Captures the element once with every image blanked out and once per batch of images,
+ * then merges each batch pass into the blank one wherever their pixels differ.
+ *
+ * html2canvas reloads every image it draws and tears its clone down while those loads
+ * are still running: a capture holding 250 image elements lost about 150 of them and
+ * the matching character cards came out blank, one holding 139 lost 4, and one holding
+ * 32 lost none. Batching the images around that limit is the way out, but the passes
+ * cannot be stitched by rectangle: the capture lays the page out a little differently
+ * from the live DOM, and copies placed at the live coordinates drifted further off with
+ * every section. Comparing pixels needs no coordinates at all, and it works because the
+ * passes differ in nothing but which images carry their picture.
+ */
+const captureInBatches = async (
+  element: HTMLElement,
+  options: Parameters<typeof html2canvas>[1]
+) => {
+  const images = Array.from(element.querySelectorAll("img"));
+  if (images.length <= CAPTURE_BATCH_SIZE) return html2canvas(element, options);
+
+  const undos: Array<() => void> = [];
+
+  const blank = (target: Element, attribute: string) => {
+    const original = target.getAttribute(attribute);
+    // A <source> can be reached through more than one image, and blanking it twice
+    // would record the blank as the value to restore and leave the page without that
+    // picture after the download.
+    if (original === null || original === TRANSPARENT_PIXEL) return;
+    undos.push(() => target.setAttribute(attribute, original));
+    target.setAttribute(attribute, TRANSPARENT_PIXEL);
+  };
+
+  const hide = (batch: Set<Element>) => {
+    images.forEach((image) => {
+      if (batch.has(image)) return;
+      image.parentElement
+        ?.querySelectorAll("source")
+        .forEach((variant) => blank(variant, "srcset"));
+      blank(image, "src");
+    });
+  };
+
+  const reveal = () => {
+    undos.forEach((undo) => undo());
+    undos.length = 0;
+  };
+
+  // Every image keeps the box it was measured at, because a blanked image that draws its
+  // own height would collapse and move everything below it out of step with the other
+  // passes.
+  const pinned: Array<() => void> = [];
+  images.forEach((image) => {
+    const rect = image.getBoundingClientRect();
+    const style = image.getAttribute("style");
+    pinned.push(() => {
+      if (style === null) image.removeAttribute("style");
+      else image.setAttribute("style", style);
+    });
+    image.setAttribute(
+      "style",
+      `${style ?? ""};width:${rect.width}px;height:${rect.height}px`
+    );
+  });
+
+  try {
+    hide(new Set());
+    const merged: HTMLCanvasElement = await html2canvas(element, options);
+    reveal();
+
+    const context = merged.getContext("2d");
+    if (!context) return merged;
+
+    const target = context.getImageData(0, 0, merged.width, merged.height);
+    const blankPixels = new Uint8ClampedArray(target.data);
+
+    for (let index = 0; index < images.length; index += CAPTURE_BATCH_SIZE) {
+      const batch = new Set<Element>(images.slice(index, index + CAPTURE_BATCH_SIZE));
+
+      hide(batch);
+      let pass: HTMLCanvasElement;
+      try {
+        pass = await html2canvas(element, options);
+      } finally {
+        reveal();
+      }
+
+      const passContext = pass.getContext("2d");
+      if (!passContext) continue;
+
+      const pixels = passContext.getImageData(0, 0, pass.width, pass.height).data;
+      for (let offset = 0; offset < pixels.length; offset += 4) {
+        if (
+          pixels[offset] === blankPixels[offset] &&
+          pixels[offset + 1] === blankPixels[offset + 1] &&
+          pixels[offset + 2] === blankPixels[offset + 2] &&
+          pixels[offset + 3] === blankPixels[offset + 3]
+        ) {
+          continue;
+        }
+
+        target.data[offset] = pixels[offset];
+        target.data[offset + 1] = pixels[offset + 1];
+        target.data[offset + 2] = pixels[offset + 2];
+        target.data[offset + 3] = pixels[offset + 3];
+      }
+    }
+
+    context.putImageData(target, 0, 0);
+
+    return merged;
+  } finally {
+    reveal();
+    pinned.forEach((undo) => undo());
+  }
+};
+
 interface DownloadProps {
   tag: string;
 }
@@ -41,20 +163,28 @@ const DownloadButton: React.FC<DownloadProps> = ({ tag }) => {
     }
 
     setModal(ModalType.loading);
+    const originalWidth = element.style.width;
+    const originalMaxWidth = element.style.maxWidth;
     try {
       // Detect dark mode and set appropriate background color
       const isDark = document.documentElement.classList.contains('dark');
+
+      // The avatar grid fills its container, so a phone keeps its narrow column count
+      // unless the element is widened to the desktop layout before it is measured.
+      if (tag === "ae-wrapper") {
+        element.style.width = `${DESKTOP_CAPTURE_WIDTH}px`;
+        element.style.maxWidth = "none";
+      }
+
       const captureWidth = element.scrollWidth;
       const captureHeight = element.scrollHeight;
 
-      const canvas = await html2canvas(element, {
-        scale: 1.1,
+      const canvas = await captureInBatches(element, {
+        scale: CAPTURE_SCALE,
         allowTaint: true,
         useCORS: true,
         width: captureWidth,
         height: captureHeight,
-        windowWidth: tag === "ae-wrapper" ? 1200 : captureWidth,
-        windowHeight: captureHeight,
         backgroundColor: isDark ? '#171717' : '#ffffff',
         ignoreElements: (element) => element.id === "downloader",
         onclone: (_: Document, clonedElement: HTMLElement) => {
@@ -185,6 +315,9 @@ const DownloadButton: React.FC<DownloadProps> = ({ tag }) => {
         text: "Please try again later.",
         confirmButtonText: "Ok",
       });
+    } finally {
+      element.style.width = originalWidth;
+      element.style.maxWidth = originalMaxWidth;
     }
   };
 

--- a/src/components/atoms/button/Download.tsx
+++ b/src/components/atoms/button/Download.tsx
@@ -14,124 +14,171 @@ const AnnounceSwal = withReactContent(Swal);
 
 const DESKTOP_CAPTURE_WIDTH = 1200;
 const CAPTURE_SCALE = 1.1;
-const CAPTURE_BATCH_SIZE = 100;
+const HIGHLIGHTS = [
+  {
+    selector: '[data-capture-highlight="recent"], .glow-recent',
+    width: 2,
+    color: "#56b4e9",
+  },
+  {
+    selector: '[data-capture-highlight="op"], .glow-op',
+    width: 2,
+    color: "rgba(250, 204, 21, 0.8)",
+  },
+  {
+    selector: '[data-capture-highlight="super_op"], .glow-super-op',
+    width: 4,
+    color: "#fde047",
+  },
+];
 const TRANSPARENT_PIXEL =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
+interface CaptureImage {
+  bitmap: HTMLCanvasElement;
+  element: HTMLImageElement;
+  layer: number;
+}
+
 /**
- * Captures the element once with every image blanked out and once per batch of images,
- * then merges each batch pass into the blank one wherever their pixels differ.
+ * Captures the element with every image blanked out and paints the pictures the page has
+ * already decoded onto the result.
  *
- * html2canvas reloads every image it draws and tears its clone down while those loads
- * are still running: a capture holding 250 image elements lost about 150 of them and
- * the matching character cards came out blank, one holding 139 lost 4, and one holding
- * 32 lost none. Batching the images around that limit is the way out, but the passes
- * cannot be stitched by rectangle: the capture lays the page out a little differently
- * from the live DOM, and copies placed at the live coordinates drifted further off with
- * every section. Comparing pixels needs no coordinates at all, and it works because the
- * passes differ in nothing but which images carry their picture.
+ * html2canvas reloads each image it draws instead of reusing the decoded one, and it
+ * tears its clone down while those loads are still running: a capture holding 250 images
+ * lost about 150 of them and the matching character cards came out blank, while one
+ * holding 32 lost none. Pointing every image at the same blank pixel leaves the capture
+ * with a single picture to load, and the real ones are drawn afterwards from the canvas
+ * copies taken here. That copying is what the crossOrigin attribute on the images is
+ * for: a canvas holding a plain cross-origin picture cannot be read back.
  */
-const captureInBatches = async (
+const captureWithImages = async (
   element: HTMLElement,
-  options: Parameters<typeof html2canvas>[1]
+  options: Parameters<typeof html2canvas>[1] & { scale: number }
 ) => {
-  const images = Array.from(element.querySelectorAll("img"));
-  if (images.length <= CAPTURE_BATCH_SIZE) return html2canvas(element, options);
-
   const undos: Array<() => void> = [];
-
-  const blank = (target: Element, attribute: string) => {
+  const set = (target: Element, attribute: string, value: string) => {
     const original = target.getAttribute(attribute);
-    // A <source> can be reached through more than one image, and blanking it twice
-    // would record the blank as the value to restore and leave the page without that
-    // picture after the download.
-    if (original === null || original === TRANSPARENT_PIXEL) return;
+    if (original === null || original === value) return;
     undos.push(() => target.setAttribute(attribute, original));
-    target.setAttribute(attribute, TRANSPARENT_PIXEL);
+    target.setAttribute(attribute, value);
   };
 
-  const hide = (batch: Set<Element>) => {
-    images.forEach((image) => {
-      if (batch.has(image)) return;
-      image.parentElement
-        ?.querySelectorAll("source")
-        .forEach((variant) => blank(variant, "srcset"));
-      blank(image, "src");
-    });
-  };
+  const bitmaps = new Map<string, HTMLCanvasElement>();
+  const drawings: CaptureImage[] = [];
 
-  const reveal = () => {
-    undos.forEach((undo) => undo());
-    undos.length = 0;
-  };
-
-  // Every image keeps the box it was measured at, because a blanked image that draws its
-  // own height would collapse and move everything below it out of step with the other
-  // passes.
-  const pinned: Array<() => void> = [];
-  images.forEach((image) => {
+  element.querySelectorAll("img").forEach((image) => {
     const rect = image.getBoundingClientRect();
-    const style = image.getAttribute("style");
-    pinned.push(() => {
-      if (style === null) image.removeAttribute("style");
-      else image.setAttribute("style", style);
-    });
-    image.setAttribute(
+    // A blanked image that draws its own height would collapse and move everything
+    // below it away from the boxes measured here.
+    set(
+      image,
       "style",
-      `${style ?? ""};width:${rect.width}px;height:${rect.height}px`
+      `${image.getAttribute("style") ?? ""};width:${rect.width}px;height:${rect.height}px`
     );
-  });
 
-  try {
-    hide(new Set());
-    const merged: HTMLCanvasElement = await html2canvas(element, options);
-    reveal();
-
-    const context = merged.getContext("2d");
-    if (!context) return merged;
-
-    const target = context.getImageData(0, 0, merged.width, merged.height);
-    const blankPixels = new Uint8ClampedArray(target.data);
-
-    for (let index = 0; index < images.length; index += CAPTURE_BATCH_SIZE) {
-      const batch = new Set<Element>(images.slice(index, index + CAPTURE_BATCH_SIZE));
-
-      hide(batch);
-      let pass: HTMLCanvasElement;
-      try {
-        pass = await html2canvas(element, options);
-      } finally {
-        reveal();
+    if (image.naturalWidth) {
+      let bitmap = bitmaps.get(image.src);
+      if (!bitmap) {
+        bitmap = document.createElement("canvas");
+        bitmap.width = image.naturalWidth;
+        bitmap.height = image.naturalHeight;
+        bitmap.getContext("2d")?.drawImage(image, 0, 0);
+        bitmaps.set(image.src, bitmap);
       }
 
-      const passContext = pass.getContext("2d");
-      if (!passContext) continue;
-
-      const pixels = passContext.getImageData(0, 0, pass.width, pass.height).data;
-      for (let offset = 0; offset < pixels.length; offset += 4) {
-        if (
-          pixels[offset] === blankPixels[offset] &&
-          pixels[offset + 1] === blankPixels[offset + 1] &&
-          pixels[offset + 2] === blankPixels[offset + 2] &&
-          pixels[offset + 3] === blankPixels[offset + 3]
-        ) {
-          continue;
-        }
-
-        target.data[offset] = pixels[offset];
-        target.data[offset + 1] = pixels[offset + 1];
-        target.data[offset + 2] = pixels[offset + 2];
-        target.data[offset + 3] = pixels[offset + 3];
-      }
+      const layer = Number(window.getComputedStyle(image).zIndex);
+      drawings.push({ bitmap, element: image, layer: Number.isNaN(layer) ? 0 : layer });
     }
 
-    context.putImageData(target, 0, 0);
+    // A <source> outranks the img's own src, so the WebP variants go blank as well.
+    // Only the image's own picture may be touched: reaching further up blanked the
+    // character art before its copy was taken, and every card came out empty.
+    image
+      .closest("picture")
+      ?.querySelectorAll(":scope > source")
+      .forEach((variant) => set(variant, "srcset", TRANSPARENT_PIXEL));
+    set(image, "src", TRANSPARENT_PIXEL);
+  });
 
-    return merged;
+  let canvas: HTMLCanvasElement;
+  try {
+    canvas = await html2canvas(element, options);
   } finally {
-    reveal();
-    pinned.forEach((undo) => undo());
+    undos.forEach((undo) => undo());
   }
+
+  const context = canvas.getContext("2d");
+  if (!context) return canvas;
+
+  // The capture leaves its own scale on the context, which multiplied every coordinate
+  // below a second time and pushed the pictures further down the page the lower they sat.
+  context.setTransform(1, 0, 0, 1, 0, 0);
+
+  const bounds = element.getBoundingClientRect();
+  const place = (target: Element) => {
+    const rect = target.getBoundingClientRect();
+    return {
+      x: (rect.left - bounds.left) * options.scale,
+      y: (rect.top - bounds.top) * options.scale,
+      width: rect.width * options.scale,
+      height: rect.height * options.scale,
+    };
+  };
+
+  // The capture holds the name plates and the highlight rings, which belong above the
+  // pictures, so it is kept aside and those parts are put back afterwards.
+  const captured = document.createElement("canvas");
+  captured.width = canvas.width;
+  captured.height = canvas.height;
+  captured.getContext("2d")?.drawImage(canvas, 0, 0);
+
+  const restore = (x: number, y: number, width: number, height: number) => {
+    if (width <= 0 || height <= 0) return;
+    context.drawImage(captured, x, y, width, height, x, y, width, height);
+  };
+
+  drawings
+    .sort((first, second) => first.layer - second.layer)
+    .forEach(({ bitmap, element: image }) => {
+      const box = place(image);
+      const style = window.getComputedStyle(image);
+
+      context.save();
+      context.filter = style.filter;
+      context.globalAlpha = Number(style.opacity);
+      context.beginPath();
+      context.roundRect(
+        box.x,
+        box.y,
+        box.width,
+        box.height,
+        parseFloat(style.borderTopLeftRadius) * options.scale || 0
+      );
+      context.clip();
+      context.drawImage(bitmap, box.x, box.y, box.width, box.height);
+      context.restore();
+    });
+
+  element.querySelectorAll("picture").forEach((picture) => {
+    const plate = picture.nextElementSibling;
+    if (!plate) return;
+    const box = place(plate);
+    restore(box.x, box.y, box.width, box.height);
+  });
+
+  HIGHLIGHTS.forEach(({ selector, width }) => {
+    const ring = width * options.scale;
+    element.querySelectorAll(selector).forEach((highlighted) => {
+      const box = place(highlighted);
+      restore(box.x, box.y, box.width, ring);
+      restore(box.x, box.y + box.height - ring, box.width, ring);
+      restore(box.x, box.y, ring, box.height);
+      restore(box.x + box.width - ring, box.y, ring, box.height);
+    });
+  });
+
+  return canvas;
 };
 
 interface DownloadProps {
@@ -179,15 +226,20 @@ const DownloadButton: React.FC<DownloadProps> = ({ tag }) => {
       const captureWidth = element.scrollWidth;
       const captureHeight = element.scrollHeight;
 
-      const canvas = await captureInBatches(element, {
+      const canvas = await captureWithImages(element, {
         scale: CAPTURE_SCALE,
         allowTaint: true,
         useCORS: true,
         width: captureWidth,
         height: captureHeight,
         backgroundColor: isDark ? '#171717' : '#ffffff',
-        ignoreElements: (element) => element.id === "downloader",
         onclone: (_: Document, clonedElement: HTMLElement) => {
+          // The button is hidden rather than dropped from the capture: dropping it took
+          // its height out of the layout, and everything below sat about 30px higher
+          // than the page it was measured from.
+          const downloader = clonedElement.querySelector<HTMLElement>("#downloader");
+          if (downloader) downloader.style.visibility = "hidden";
+
           clonedElement.style.width = `${captureWidth}px`;
           clonedElement.style.height = `${captureHeight}px`;
           clonedElement.style.maxHeight = "none";
@@ -195,22 +247,7 @@ const DownloadButton: React.FC<DownloadProps> = ({ tag }) => {
           clonedElement.scrollLeft = 0;
           clonedElement.scrollTop = 0;
 
-          const highlights = [
-            {
-              selector: '[data-capture-highlight="recent"], .glow-recent',
-              border: "2px solid #56b4e9",
-            },
-            {
-              selector: '[data-capture-highlight="op"], .glow-op',
-              border: "2px solid rgba(250, 204, 21, 0.8)",
-            },
-            {
-              selector: '[data-capture-highlight="super_op"], .glow-super-op',
-              border: "4px solid #fde047",
-            },
-          ];
-
-          highlights.forEach(({ selector, border }) => {
+          HIGHLIGHTS.forEach(({ selector, width, color }) => {
             clonedElement.querySelectorAll<HTMLElement>(selector).forEach((highlighted) => {
               highlighted.style.setProperty("box-shadow", "none", "important");
               const position = highlighted.ownerDocument.defaultView
@@ -223,7 +260,7 @@ const DownloadButton: React.FC<DownloadProps> = ({ tag }) => {
               Object.assign(overlay.style, {
                 position: "absolute",
                 inset: "0",
-                border,
+                border: `${width}px solid ${color}`,
                 borderRadius: "inherit",
                 boxSizing: "border-box",
                 pointerEvents: "none",

--- a/src/components/atoms/character/Avatar.tsx
+++ b/src/components/atoms/character/Avatar.tsx
@@ -14,10 +14,9 @@ interface CharacterCheckProps {
   onClick: () => void;
 }
 
-// Every CDN image here carries crossOrigin="anonymous". The download button captures
-// this grid with html2canvas, which reloads each image in CORS mode; without the
-// attribute the page caches a plain response instead, that reload comes back empty, and
-// the downloaded image loses those pictures. The style badges vanished that way.
+// Every CDN image here carries crossOrigin="anonymous". The download button copies
+// these pictures into canvases so that the capture does not reload them, and a canvas
+// holding a plain cross-origin picture cannot be exported afterwards.
 // 캐릭터 체크 UI
 const CharacterAvatar: React.FC<CharacterCheckProps> = ({
   info,

--- a/src/components/atoms/character/Avatar.tsx
+++ b/src/components/atoms/character/Avatar.tsx
@@ -14,6 +14,10 @@ interface CharacterCheckProps {
   onClick: () => void;
 }
 
+// Every CDN image here carries crossOrigin="anonymous". The download button captures
+// this grid with html2canvas, which reloads each image in CORS mode; without the
+// attribute the page caches a plain response instead, that reload comes back empty, and
+// the downloaded image loses those pictures. The style badges vanished that way.
 // 캐릭터 체크 UI
 const CharacterAvatar: React.FC<CharacterCheckProps> = ({
   info,
@@ -45,6 +49,7 @@ const CharacterAvatar: React.FC<CharacterCheckProps> = ({
         <div className="absolute bottom-[-8px] left-[-5px] z-10">
           <div className="relative w-[23px] h-[23px] bg-black/60 rounded-full flex items-center justify-center">
             <img
+              crossOrigin="anonymous"
               src={`${process.env.NEXT_PUBLIC_CDN_URL}/icon/crown.png`}
               alt="complete"
               className="w-[18px] h-[18px]"
@@ -59,6 +64,7 @@ const CharacterAvatar: React.FC<CharacterCheckProps> = ({
     if (info.style === AECharacterStyles.four) return null;
     return (
       <img
+        crossOrigin="anonymous"
         src={`${
           process.env.NEXT_PUBLIC_CDN_URL
         }/icon/${info.style.toLowerCase()}.png`}
@@ -72,6 +78,7 @@ const CharacterAvatar: React.FC<CharacterCheckProps> = ({
     if (currentGrastaStep === 0) return null;
     return (
       <img
+        crossOrigin="anonymous"
         src={`${
           process.env.NEXT_PUBLIC_CDN_URL
         }/icon/grasta${currentGrastaStep}.png`}
@@ -88,6 +95,7 @@ const CharacterAvatar: React.FC<CharacterCheckProps> = ({
       <div className="absolute bottom-[-8px] left-[-5px] z-10">
         <div className="relative w-[23px] h-[23px] bg-black/60 rounded-full flex items-center justify-center">
           <img
+            crossOrigin="anonymous"
             src={`${process.env.NEXT_PUBLIC_CDN_URL}/icon/weapontempering.png`}
             alt="weapon tempering"
             className="w-[18px] h-[18px]"
@@ -128,6 +136,7 @@ const CharacterAvatar: React.FC<CharacterCheckProps> = ({
               type="image/webp"
             />
             <img
+              crossOrigin="anonymous"
               src={`${process.env.NEXT_PUBLIC_CDN_URL}/staralign/${info.id}.png`}
               alt={info.id}
               className={cn(
@@ -143,6 +152,7 @@ const CharacterAvatar: React.FC<CharacterCheckProps> = ({
               type="image/webp"
             />
             <img
+              crossOrigin="anonymous"
               src={`${process.env.NEXT_PUBLIC_CDN_URL}/character/${info.id}.png`}
               alt={info.id}
               className={cn(

--- a/src/components/molecules/GlobalModal.tsx
+++ b/src/components/molecules/GlobalModal.tsx
@@ -5,6 +5,7 @@ import { ModalType } from "../../constants/enum";
 import FilterModal from "../atoms/FilterModal";
 import SettingsModal from "../atoms/SettingsModal";
 import Loading from "../atoms/Loading";
+import { useTranslation } from "react-i18next";
 
 interface GlobalModalProps {
   type: ModalType | undefined;
@@ -12,6 +13,7 @@ interface GlobalModalProps {
 
 const GlobalModal: React.FC<GlobalModalProps> = ({ type }) => {
   const { hideModal } = useModalStore();
+  const { t } = useTranslation();
 
   const popModal = (e: PopStateEvent) => {
     e.preventDefault();
@@ -37,7 +39,7 @@ const GlobalModal: React.FC<GlobalModalProps> = ({ type }) => {
       case ModalType.settings:
         return <SettingsModal />;
       case ModalType.loading:
-        return <Loading />;
+        return <Loading message={t("frontend.download.loading")} />;
     }
   }
 };

--- a/src/components/organisms/analysis/LegacyAnalysis.tsx
+++ b/src/components/organisms/analysis/LegacyAnalysis.tsx
@@ -143,6 +143,7 @@ const LegacyAnalysis: React.FC<AnalysisProps> = ({ allCharacters }) => {
               <h4 className="flex items-center gap-2 text-base font-semibold mb-3 pb-2 border-b border-border text-foreground">
                 {p.startsWith("personality") && (
                   <img
+                    crossOrigin="anonymous"
                     src={`${process.env.NEXT_PUBLIC_CDN_URL}/icon/${p}.png`}
                     alt={p}
                     className="w-6 h-6"

--- a/src/components/organisms/analysis/LegacyTableAnalysis.tsx
+++ b/src/components/organisms/analysis/LegacyTableAnalysis.tsx
@@ -49,6 +49,7 @@ const LegacyTableAnalysis: React.FC<AnalysisProps> = ({ allCharacters }) => {
               className="sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border shadow-sm p-4 flex items-center justify-center border-l border-border/50"
             >
               <img
+                crossOrigin="anonymous"
                 src={`${process.env.NEXT_PUBLIC_CDN_URL}/icon/${element}.png`}
                 alt={element}
                 className="w-8 h-8 object-contain"
@@ -62,6 +63,7 @@ const LegacyTableAnalysis: React.FC<AnalysisProps> = ({ allCharacters }) => {
               {/* Row Header (Weapon) */}
               <div className="bg-background border-r border-border p-4 flex items-center justify-center sticky left-0 z-[5] border-b border-border/50">
                 <img
+                  crossOrigin="anonymous"
                   src={`${process.env.NEXT_PUBLIC_CDN_URL}/icon/${weapon}.png`}
                   alt={weapon}
                   className="w-8 h-8 object-contain"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,4 +1,5 @@
 {
+  "frontend.download.loading": "Creating the image. This takes a few seconds when there are many characters.",
   "frontend.menu.analysis": "Analysis",
   "frontend.menu.check": "Check",
   "frontend.menu.loader": "Data Save & Load",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "frontend.download.loading": "Creating the image. This takes a few seconds when there are many characters.",
+  "frontend.download.loading": "Creating the image.",
   "frontend.menu.analysis": "Analysis",
   "frontend.menu.check": "Check",
   "frontend.menu.loader": "Data Save & Load",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -1,4 +1,5 @@
 {
+  "frontend.download.loading": "画像を作成しています。キャラクターが多い場合は数秒かかります。",
   "frontend.menu.analysis": "分析",
   "frontend.menu.check": "チェック",
   "frontend.menu.loader": "データ Save & Load",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -1,5 +1,5 @@
 {
-  "frontend.download.loading": "画像を作成しています。キャラクターが多い場合は数秒かかります。",
+  "frontend.download.loading": "画像を作成しています。",
   "frontend.menu.analysis": "分析",
   "frontend.menu.check": "チェック",
   "frontend.menu.loader": "データ Save & Load",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -1,4 +1,5 @@
 {
+  "frontend.download.loading": "이미지를 만드는 중입니다. 캐릭터가 많으면 몇 초 정도 걸립니다.",
   "frontend.menu.analysis": "분석",
   "frontend.menu.check": "체크",
   "frontend.menu.loader": "데이터 저장 & 불러오기",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -1,5 +1,5 @@
 {
-  "frontend.download.loading": "이미지를 만드는 중입니다. 캐릭터가 많으면 몇 초 정도 걸립니다.",
+  "frontend.download.loading": "이미지를 만드는 중입니다.",
   "frontend.menu.analysis": "분석",
   "frontend.menu.check": "체크",
   "frontend.menu.loader": "데이터 저장 & 불러오기",


### PR DESCRIPTION
## Problem

Downloading the analysis image produced a picture with most character cards blank, and on a phone it came out in the narrow phone layout instead of the wide one.

html2canvas clones the page and reloads every image by address instead of reusing the one the page already decoded, then tears the clone down while those loads are still running. A capture holding 250 image elements lost about 150 of them; 139 lost 4; 32 lost none. Separately, `windowWidth` only moves the clone media queries, so the element itself stayed at the phone width, and the clone even picked up desktop padding that the measured height did not account for.

## Change

- Each image in the clone is replaced with a canvas holding the picture that image already shows, so the capture has nothing to load. The layout, name plates, badges and highlight rings still come from the page itself.
- The element is widened to the desktop width before it is measured, so a phone download matches what the page looks like on a desktop.
- CDN images carry `crossOrigin="anonymous"`, because a canvas holding a plain cross-origin picture cannot be exported afterwards.
- The loading overlay says an image is being created.

## Verification

`austincli agent check` passes (eslint, tsc, next build).

Checked against the running app at a 412x900 viewport:

| View | Images | Result |
|---|---|---|
| Selector recommendation | 634 | 0.6s, 1320x3580, every picture, badge, name plate and highlight ring present |
| Table, dark mode | 766 | 0.7s, grayscale filter and highlight ring preserved |

No capture errors are logged in either view.

## Note on the history

The first three commits fixed the same bug by capturing in batches of 100 images and merging the passes, then by copying the pictures onto the finished canvas. Both worked, but the second one carried its own coordinate mapping, layer ordering and overlay restoring, at 192 added lines and 3.2s. The last commit replaces all of that with the canvas swap above: 49 added lines, same output, same speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)